### PR TITLE
Multi-line comment syntax highlighting and autoclose

### DIFF
--- a/language-configuration.json
+++ b/language-configuration.json
@@ -2,6 +2,7 @@
     "comments": {
         // symbol used for single line comment. Remove this entry if your language does not support line comments
         "lineComment": "--",
+        // symbol used for multi-line comments
         "blockComment": ["{-","-}"]
     },
     // symbols used as brackets

--- a/language-configuration.json
+++ b/language-configuration.json
@@ -1,7 +1,8 @@
 {
     "comments": {
         // symbol used for single line comment. Remove this entry if your language does not support line comments
-        "lineComment": "--"
+        "lineComment": "--",
+        "blockComment": ["{-","-}"]
     },
     // symbols used as brackets
     "brackets": [
@@ -10,9 +11,11 @@
     // symbols that are auto closed when typing
     "autoClosingPairs": [
         { "open": "(", "close": ")" },
+        { "open": "{-", "close": "-}" }
     ],
     // symbols that that can be used to surround a selection
     "surroundingPairs": [
         ["(", ")"],
+        ["{-","-}"]
     ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "elsa-lang",
-    "version": "1.0.2",
+    "version": "1.0.3",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "elsa-lang",
-            "version": "1.0.2",
+            "version": "1.0.3",
             "devDependencies": {
                 "@types/vscode": "^1.75.0"
             },

--- a/syntaxes/elsa.tmLanguage.json
+++ b/syntaxes/elsa.tmLanguage.json
@@ -122,10 +122,24 @@
 			]
 		},
 		"comments": {
-			"name": "comment.line.double-dash.elsa",
-			"begin": "--",
-			"end": "(?=\n)",
-			"patterns": []
+			"name": "comment.block.elsa",
+			"patterns": [
+				{
+					"name": "comment.line.double-dash.elsa",
+					"begin": "--",
+					"end": "(?=\n)"
+				},
+				{
+					"name": "comment.block-multi-line.elsa",
+					"begin": "\\{-",
+					"end": "-\\}",
+					"pattens": [
+						{
+							"include": "#comments"
+						}
+					]
+				}
+			]
 		}
 	},
 	"scopeName": "source.elsa"


### PR DESCRIPTION
Elsa supports multi-line comments through the usage of `{- Comment Inside -}`, however, this wasn't included in the vs code extension. I have modified elsa.tmLanguage.json so it has comment syntax highlighting and language-configuration.json to make them autoclose. Let me know if there is anything else needed.